### PR TITLE
--link alias syntax to work with docker version >1.10

### DIFF
--- a/2-weblogic.sh
+++ b/2-weblogic.sh
@@ -6,7 +6,7 @@ docker build -t owcs/2-weblogic:latest install-weblogic
 # configure weblogic
 docker run -h shared.loc --name shared.loc \
   -p 1521:1521 -d owcs/2-shared
-docker run -h sites.loc --name sites.loc --link shared.loc \
+docker run -h sites.loc --name sites.loc --link shared.loc:shared.loc \
   -ti owcs/2-weblogic \
   bash install-weblogic.sh
 docker stop shared.loc

--- a/3-sites.sh
+++ b/3-sites.sh
@@ -17,7 +17,7 @@ docker run -h shared.loc --name shared.loc \
   -p 1521:1521 \
   -d owcs/2-shared
 docker run -h sites.loc --name sites.loc \
-  --link shared.loc \
+  --link shared.loc:shared.loc \
   --add-host "$EXTRA_HOST" \
   -p 7003:7003 -p 7001:7001 \
   -ti owcs/3-sites-$DB \

--- a/base-sites/Dockerfile
+++ b/base-sites/Dockerfile
@@ -6,4 +6,4 @@ WORKDIR /app
 RUN jar xvf /sites.zip.zip
 USER app
 COPY oraInst.loc sites.rsp /app/
-RUN java -jar *.jar -responseFile /app/sites.rsp -silent -invPtrLoc /app/oraInst.loc ; rm *.jar
+RUN java -jar *.jar -responseFile /app/sites.rsp -silent -invPtrLoc /app/oraInst.loc -ignoreSysPrereqs -force -novalidation ; rm *.jar

--- a/base-sites/sites.rsp
+++ b/base-sites/sites.rsp
@@ -3,4 +3,4 @@ Response File Version=1.0.0.0.0
 [GENERIC]
 DECLINE_AUTO_UPDATES=true
 ORACLE_HOME=/app/weblogic
-INSTALL_TYPE=WebCenter Sites
+INSTALL_TYPE=WebCenter Sites - With Examples


### PR DESCRIPTION
Hi, 
I had problems building with Docker version 1.10.0, build 590d5108 because the syntax for the --link parameter seems to be changed a bit. An alias is always required. I succeeded to build with these small changes. 
Have a nice day, 
Andras 
